### PR TITLE
Discontinue WMIC, use powershell

### DIFF
--- a/lib/disk.js
+++ b/lib/disk.js
@@ -40,26 +40,30 @@ switch(process.env.platform) {
         
     case 'win': 
         module.exports = function(statEmitter, options) {
-            let wmic = 'wmic LOGICALDISK GET Name, Size, FreeSpace /value | findstr "FreeSpace Name Size"';
-            exec(wmic, function(err, output, code) {
+            let powershell = 'powershell Get-CimInstance -ClassName Win32_LogicalDisk';
+            exec(powershell, function(err, output, code) {
                 if(err) return;
                 
                 let segments = output.split('\n');
-                for(let i=0; i<segments.length; ++i) {
-                    if(segments[i].includes('FreeSpace')) {
-                        let free = segments[i].split('=')[1].split('\r\r')[0];
-                        if(!free) return;
-                        
-                        free = parseInt(free);
-                        let filesystem = segments[i+1].split('=')[1].split('\r\r')[0];
-                        if(options.diskfilesystems && options.diskfilesystems.indexOf(filesystem) < 0) return;
-                        
-                        let total = parseInt(segments[i+2].split('=')[1].split('\r\r')[0]);
-                        let usedpct = Number(parseFloat((total - free) / total * 100).toFixed(2));
-                        
-                        if(!options.threshold || options.threshold === 0 || usedpct > options.threshold) {
-                            statEmitter.emit('disk', { filesystem: filesystem, usedpct: usedpct, total: total, free: free });
-                        }
+                for(let i=3; i<segments.length; ++i) {
+                    let segment = segments[i].split(/\s+/)
+
+                    if (segment.length < 3) {
+                        continue;
+                    }
+
+                    let free = segment[4];
+                    if(!free) return;
+                    
+                    free = parseInt(free);
+                    let filesystem = segment[0];
+                    if(options.diskfilesystems && options.diskfilesystems.indexOf(filesystem) < 0) return;
+                    
+                    let total = parseInt(segment[4]);
+                    let usedpct = Number(parseFloat((total - free) / total * 100).toFixed(2));
+                    
+                    if(!options.threshold || options.threshold === 0 || usedpct > options.threshold) {
+                        statEmitter.emit('disk', { filesystem: filesystem, usedpct: usedpct, total: total, free: free });
                     }
                 }
                 


### PR DESCRIPTION
WMIC is deprecated on Windows 10 21H1 and later so using powershell commands from now on would be recommended.  
Closes #5